### PR TITLE
Fix the ask to open in browser dialog on Mac.

### DIFF
--- a/lib/git_reflow/sandbox.rb
+++ b/lib/git_reflow/sandbox.rb
@@ -39,7 +39,7 @@ module GitReflow
 
     # WARNING: this currently only supports OS X and UBUNTU
     def ask_to_open_in_browser(url)
-      if OS.linux?
+      if OS.linux? || OS.mac?
         open_in_browser = ask "Would you like to open it in your browser? "
         if open_in_browser =~ /^y/i
           if OS.mac?


### PR DESCRIPTION
Why:
- GitReflow::Sandbox#ask_to_open_in_browser method currently only works
  for linux.

This change addresses the need by:
- Add OS.mac? to the initial if statement guarding other platforms.
